### PR TITLE
fix: correct import location

### DIFF
--- a/libyear/libyear
+++ b/libyear/libyear
@@ -3,8 +3,8 @@ import argparse
 
 from prettytable import PrettyTable
 
-from libyear.pypi import get_lib_days
-from libyear.utils import load_requirements, get_requirement_files, get_requirement_name_and_version, get_no_of_releases
+from libyear.pypi import get_lib_days, get_no_of_releases
+from libyear.utils import load_requirements, get_requirement_files, get_requirement_name_and_version
 
 
 def main():


### PR DESCRIPTION
In #15 this import was incorrectly places on the `libyear.utils` line instead of the `libyear.pypi` line, where the new code was included, resulting in this error:

```python
ImportError: cannot import name 'get_no_of_releases' from 'libyear.utils' (/home/codespace/.local/lib/python3.8/site-packages/libyear-0.2.0-py3.8.egg/libyear/utils.py)
```