### PR TITLE
fix: set content type for readme

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python
+from os import path
 
 from setuptools import setup
+
+
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
 
 setup(
     name="libyear",
     version="0.2.0",
     description="A simple measure of software dependency freshness.",
-    long_description=open("README.md").read(),
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     author="nasirhjafri",
     url="https://github.com/nasirhjafri/libyear",
     classifiers=[


### PR DESCRIPTION
Resolves #10 

- Extracts the reading of the README.md file to a context manager that safely closes the file once completed reading.
- Adds a content-type that pypi will understand, based on the [official documentation](https://packaging.python.org/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata).