### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,20 +1,26 @@
 name: Python package
 
-on: [push]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
 
     steps:
-    - uses: actions/checkout@v1
+    - name: Checkout
+      uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,16 +1,9 @@
 name: Python package
 
-on:
-  push:
-    branches:
-    - master
-  pull_request:
-    branches:
-    - master
+on: [pull_request, push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
I've recently found this library and it looks pretty interesting to me, so I want to contribute one or two things to improve it. 😊 

This PR updates the GitHub actions workflow. Changes:

- Enable the action to be run on pull requests as well. ~Note: I'm not sure if [this](https://docs.github.com/en/github/administering-a-repository/disabling-or-limiting-github-actions-for-a-repository#enabling-workflows-for-private-repository-forks) needs to be enabled as well in order for it to work on forks, but probably yes. So could you @nasirhjafri enable it?~ **Edit:** Seems like it works. 👍🏼 

- Extend the testing to Python 3.8, 3.9 and as well to the development version of 3.10.

- `max-parallel: 4` is obsolete, as GitHub runs jobs [by default ](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymax-parallel) on the maximum available runners.

- Update `actions/checkout` and `actions/setup-python` to the latest versions (v2).


Note: I'm not very experienced with GitHub actions, so I'm open to improvements! 😊 