### PR TITLE
Remove dateutil as dependency

### DIFF
--- a/libyear/pypi.py
+++ b/libyear/pypi.py
@@ -1,6 +1,6 @@
 from distutils.version import LooseVersion
 
-import dateutil.parser
+from datetime import datetime
 import requests
 
 
@@ -73,7 +73,7 @@ def get_version_release_dates(name, version, version_lt):
         print(f'Latest version of {name!r} has no upload time.')
         return None, None, None, None
 
-    latest_version_date = dateutil.parser.parse(latest_version_date)
+    latest_version_date = datetime.strptime(latest_version_date, "%Y-%m-%dT%H:%M:%S.%fZ")
     if version not in releases:
         return None, latest_version_date, latest_version, latest_version_date
 
@@ -83,7 +83,7 @@ def get_version_release_dates(name, version, version_lt):
         print(f'Used release of {name}=={version} has no upload time.')
         return None, None, None, None
 
-    version_date = dateutil.parser.parse(version_date)
+    version_date = datetime.strptime(version_date, "%Y-%m-%dT%H:%M:%S.%fZ")
     return version, version_date, latest_version, latest_version_date
 
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
     install_requires=[
         "requests>=2.0.0",
         "prettytable>=0.7.2",
-        "python-dateutil>=2.7.0",
     ],
     setup_requires=["pytest-runner"],
 )


### PR DESCRIPTION
[python-dateutil](https://pypi.org/project/python-dateutil/) is one of the few dependencies.

It's only used twice in the `pypi.py` file to create datetime objects from strings. E.g.:

```
version_date = dateutil.parser.parse(version_date)
```

But the same can as well easily be achieved with the standard library datetime module:
```
version_date = datetime.strptime(version_date, "%Y-%m-%dT%H:%M:%S.%fZ")
```


So this PR aims at removing `python-dateutil` as dependency and using `datetime` instead.
